### PR TITLE
fix: 백엔드 DB 연결 설정을 GitHub Secrets 환경변수로 변경

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -66,8 +66,20 @@ jobs:
           username: ${{ secrets.KT_SERVER_USER }}
           port: ${{ secrets.KT_SSH_PORT }}
           password: ${{ secrets.KT_SERVER_PASSWORD }}
+          envs: DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,BACKEND_PORT,FRONTEND_PORT
           script: |
             cd ~/simple-quiz-app
+
+            # .env 파일 생성
+            cat > .env << EOF
+            DB_HOST=${{ secrets.DB_HOST }}
+            DB_PORT=${{ secrets.DB_PORT }}
+            DB_NAME=${{ secrets.DB_NAME }}
+            DB_USERNAME=${{ secrets.DB_USERNAME }}
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            BACKEND_PORT=${{ secrets.BACKEND_PORT }}
+            FRONTEND_PORT=${{ secrets.FRONTEND_PORT }}
+            EOF
 
             # Docker 이미지 로드
             docker load < ~/quiz-backend.tar.gz

--- a/docker-compose-external-mysql.yml
+++ b/docker-compose-external-mysql.yml
@@ -8,8 +8,8 @@ services:
       dockerfile: Dockerfile
     container_name: quiz-backend
     environment:
-      DB_HOST: 192.168.0.84  # 외부 MySQL 서버 IP
-      DB_PORT: 3306
+      DB_HOST: ${DB_HOST:-mysql}
+      DB_PORT: ${DB_PORT:-3306}
       DB_NAME: ${DB_NAME:-quiz_app_db}
       DB_USERNAME: ${DB_USERNAME:-root}
       DB_PASSWORD: ${DB_PASSWORD:-password}


### PR DESCRIPTION
- docker-compose에 하드코딩된 DB_HOST를 환경변수로 변경
- GitHub Actions에서 Secrets의 DB 설정을 .env 파일로 생성
- MySQL 컨테이너와의 네트워크 연결 문제 해결
