### PR TITLE
feat: HTTPS 지원을 위한 SSL 인증서 및 nginx 리버스 프록시 추가

### DIFF
--- a/backend/src/main/java/saffy/backend/controller/QuizController.java
+++ b/backend/src/main/java/saffy/backend/controller/QuizController.java
@@ -17,7 +17,8 @@ import java.util.Optional;
         "http://localhost:5173",
         "http://localhost:5174",
         "https://zhy2on.github.io",
-        "https://ssafy-quiz-club.github.io"
+        "https://ssafy-quiz-club.github.io",
+        "https://quiz-api.kro.kr"
     },
     allowCredentials = "true"
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,27 @@ services:
       DB_NAME: ${DB_NAME:-quiz_app_db}
       DB_USERNAME: ${DB_USERNAME:-root}
       DB_PASSWORD: ${DB_PASSWORD:-password}
-    ports:
-      - "8080:8080"
+    # ports:
+    #   - "8080:8080"  # nginx가 프록시하므로 외부 노출 불필요
     depends_on:
       mysql:
         condition: service_healthy
+    networks:
+      - quiz-network
+    restart: unless-stopped
+
+  # Nginx 리버스 프록시 (HTTPS)
+  nginx:
+    image: nginx:alpine
+    container_name: quiz-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - /root/.acme.sh/quiz-api.kro.kr_ecc:/etc/nginx/ssl:ro
+    depends_on:
+      - backend
     networks:
       - quiz-network
     restart: unless-stopped

--- a/frontend/src/services/axiosInstance.ts
+++ b/frontend/src/services/axiosInstance.ts
@@ -9,7 +9,7 @@ const getCookie = (name: string): string | null => {
 };
 
 const axiosInstance = axios.create({
-    baseURL: "http://211.254.215.138:8080/api",  // KT Cloud 백엔드 서버
+    baseURL: "https://quiz-api.kro.kr/api",  // HTTPS 백엔드 서버
     withCredentials: true, // ✅ 이거 있어야 쿠키 보내짐!
 });
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name quiz-api.kro.kr;
+
+    # HTTP를 HTTPS로 리다이렉트
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name quiz-api.kro.kr;
+
+    # SSL 인증서 설정
+    ssl_certificate /etc/nginx/ssl/fullchain.cer;
+    ssl_certificate_key /etc/nginx/ssl/quiz-api.kro.kr.key;
+
+    # SSL 설정 강화
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # 프록시 설정
+    location / {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # CORS 헤더 (필요시)
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS";
+        add_header Access-Control-Allow-Headers "Content-Type, Authorization";
+    }
+}


### PR DESCRIPTION
- ZeroSSL을 통한 quiz-api.kro.kr SSL 인증서 발급
- nginx 리버스 프록시 컨테이너 추가 (HTTPS 처리)
- 백엔드 CORS 설정에 quiz-api.kro.kr 도메인 추가
- 프론트엔드 API URL을 HTTPS로 변경
- HTTP 요청 자동 HTTPS 리다이렉트 설정
