### PR TITLE
fix: GitHub Pages 배포 방식을 공식 Actions로 변경

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -9,14 +9,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
 
@@ -26,17 +29,33 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - run: npm ci
-      - run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
-      # SPA 새로고침 404 대응
-      - run: cp -f dist/index.html dist/404.html || true
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
 
-      # gh-pages 브랜치로 배포
-      - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Build
+        run: npm run build
+        working-directory: frontend
+
+      - name: SPA 404 대응
+        run: cp -f dist/index.html dist/404.html || true
+        working-directory: frontend
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: frontend/dist
-          # 커스텀 도메인이면: cname: your.domain.com
+          path: frontend/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- peaceiris/actions-gh-pages 대신 공식 deploy-pages 사용
- 권한 설정 업데이트 (pages: write, id-token: write)
- build/deploy 잡 분리
- 매번 강제 재배포 없이 자동 배포 가능
