### PR TITLE
프론트엔드: Answer의 explanation 필드 처리

### DIFF
--- a/frontend/src/pages/QuizPage.tsx
+++ b/frontend/src/pages/QuizPage.tsx
@@ -37,17 +37,18 @@ function mapApiQuestionsToUi(questions: ApiQuestionDto[]): UiQuestion[] {
     const choices = (q.answers ?? []).map(a => (a.content ?? a.text ?? '').toString());
     const answerIndex = Math.max(0, (q.answers ?? []).findIndex(a => a.correct === true));
 
-    const explanation =
-      q.explanations?.[0]?.content ??
-      q.explanations?.[0]?.text ??
-      undefined;
+    // 각 Answer의 explanation을 모아서 조합 (번호와 함께)
+    const explanationParts = (q.answers ?? [])
+      .map((a, idx) => a.explanation ? `${idx + 1}. ${a.explanation}` : null)
+      .filter(Boolean);
+    const explanation = explanationParts.length > 0 ? explanationParts.join('\n') : undefined;
 
     return {
       id: q.id,
       prompt: q.content,
       choices,
       answer: answerIndex === -1 ? 0 : answerIndex,
-      explanation, // ✅ 추가
+      explanation,
     };
   });
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,7 @@ export interface ApiAnswer {
   content?: string;
   text?: string;
   correct?: boolean; // 정답 여부
+  explanation?: string; // 각 보기별 해설
 }
 
 export interface ApiExplanation {


### PR DESCRIPTION
- types.ts: ApiAnswer에 explanation 필드 추가
- QuizPage.tsx: 각 Answer의 explanation을 조합하여 표시 (기존 explanations 배열 대신 각 Answer의 explanation 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)